### PR TITLE
Add possibility to print the percentage as decimals

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,17 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "9f04d1ff1afbccd02279338a2c91e5f27c45e93a",
-          "version": "0.0.5"
+          "revision": "82905286cc3f0fa8adc4674bf49437cab65a8373",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
+          "version": "1.1.1"
         }
       },
       {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core",
         "state": {
           "branch": null,
-          "revision": "3b6b97d612b56e25d80d0807f5bc38ea08b7bdf3",
-          "version": "0.2.3"
+          "revision": "b7667f3e266af621e5cc9c77e74cacd8e8c00cb4",
+          "version": "0.2.5"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.0.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.2.3"),
         .package(url: "https://github.com/onevcat/Rainbow", from: "3.2.0"),
     ],

--- a/Sources/GoSwifty/Commands/Analyze.swift
+++ b/Sources/GoSwifty/Commands/Analyze.swift
@@ -15,10 +15,13 @@ struct Analyze: ParsableCommand {
     @Argument(help: "List of folders to analyze")
     private var paths: [String]
 
+    @Option(name: .shortAndLong, help: "The number of decimals for the percentage value.")
+    var decimals: Int = 0
+
     func run() throws {
         let analyzer = Analyzer(with: paths)
         printIntro(analyzer: analyzer)
-        analyzer.coverages.forEach { $0.write() }
+        analyzer.coverages.forEach { $0.write(decimals: decimals) }
     }
 
     private func printIntro(analyzer: Analyzer) {

--- a/Sources/GoSwifty/Coverages/Coverage.swift
+++ b/Sources/GoSwifty/Coverages/Coverage.swift
@@ -15,19 +15,19 @@ protocol Coverage {
 }
 
 extension Coverage {
-    var swiftPercentage: Int {
+    var swiftPercentage: Double {
         [swift, objc].asPercentage[0]
     }
-    var objcPercentage: Int {
+    var objcPercentage: Double {
         [swift, objc].asPercentage[1]
     }
 
-    func write() {
+    func write(decimals: Int) {
         print("")
         print("> \(title)".bold)
         print(">> Swift: ".green.bold, terminator: "")
-        print("\(swift) (\(swiftPercentage)%)".red.bold)
+        print("\(swift) (\(String(format: "%.\(decimals)f", swiftPercentage))%)".red.bold)
         print(">> Objective-C: ".cyan.bold, terminator: "")
-        print("\(objc) (\(objcPercentage)%)".red.bold)
+        print("\(objc) (\(String(format: "%.\(decimals)f", objcPercentage))%)".red.bold)
     }
 }

--- a/Sources/GoSwifty/Utils.swift
+++ b/Sources/GoSwifty/Utils.swift
@@ -26,7 +26,7 @@ func numberOfOccurences(at path: String, word: String) -> Int? {
 }
 
 extension Array where Element == Int {
-    var asPercentage: [Int] {
-        self.map { $0 == 0 ? 0 : Int((Float($0) / Float(self.reduce(0, +))) * 100) }
+    var asPercentage: [Double] {
+        self.map { $0 == 0 ? 0 : (Double($0) / Double(self.reduce(0, +))) * 100 }
     }
 }


### PR DESCRIPTION
## Description
For very large mixed projects it could be that rewriting only small files doesn't increase the Swift percentage by over one percent. In this case, the tool will bring a different number of LOC, however, will still print the same percentage.

- This PR adds the possibility to specify the wanted decimal places.
- To not break the support for the existing version the default value is `0`.

In order to enable this new option, I had to update the `swift-argument-parser` to the latest version as default values were not supported in the previously used version.

## Example
```sh
goswifty analyze ... -d 2
```
_Input validation is handled by the `swift-argument-parser` lib_


